### PR TITLE
the number version in the builded manpage comes from the C source code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,16 @@ OBJFILES = main.o rolldice.o
 LIBS = -lm -lreadline
 INCLUDES = rolldice.h
 
-all: rolldice
-	
+
+MAJOR_VERSION = $(shell grep MAJOR_VERSION version.h | cut --delim " " --field 6 | cut --delim ";" --field 1)
+MINOR_VERSION = $(shell grep MINOR_VERSION version.h | cut --delim " " --field 6 | cut --delim ";" --field 1)
+VERSION = $(MAJOR_VERSION).$(MINOR_VERSION)
+
+all: rolldice man
+
 rolldice: $(OBJFILES)
 	$(CC) $(OBJFILES) -g -o rolldice $(LIBS)
-	
+
 main.o: main.c $(INCLUDES)
 	$(CC) -g -c main.c
 
@@ -25,5 +30,8 @@ install: $(EXECFILES)
 	gzip -9 -c rolldice.6 > rolldice.6.gz
 	install -m644 rolldice.6.gz $(MAN)
 
+man:
+	sed s/__VERSION__/$(VERSION)/ rolldice.6.src > rolldice.6
+
 clean:
-	rm -f ./rolldice $(OBJFILES) rolldice.6.gz
+	rm -f ./rolldice $(OBJFILES) rolldice.6 rolldice.6.gz

--- a/main.c
+++ b/main.c
@@ -9,10 +9,8 @@
  */
 
 #include "rolldice.h"
+#include "version.h"
 
-/* The version number :) */
-static const int MAJOR_VERSION = 1;
-static const int MINOR_VERSION = 11;
 
 /* The long options for this program in an struct option array */
 struct option long_opts[] = {{"help", 0, NULL, 'h'},

--- a/rolldice.6.src
+++ b/rolldice.6.src
@@ -1,4 +1,4 @@
-.\" Man file for rolldice(6) - v1.11 - 01 Feb 2010
+.\" Man file for rolldice(6) - v__VERSION__ - 01 Feb 2010
 .\" (c) Stevie Strickland, 1999-2012
 .\"
 .TH ROLLDICE 6 "01 Feb 2010" Linux
@@ -102,4 +102,4 @@ coder...
 .SH AUTHOR
 Stevie Strickland <sstrickl@ccs.neu.edu>
 .SH VERSION
-1.11 - 01 Feb 2010
+__VERSION__ - 01 Feb 2010

--- a/version.h
+++ b/version.h
@@ -1,0 +1,10 @@
+/*
+ * version.c - 13 May 2012
+ *
+ * This program has been placed under the GPL.  Any bugfixes or enhancements
+ * will be greatly appreciated :)
+ */
+
+/* The version number :) */
+static const int MAJOR_VERSION = 1;
+static const int MINOR_VERSION = 11;


### PR DESCRIPTION
Hello Steevie,

This is the patch, mainly in the Makefile, in order to retrieve the VERSION from the C code (now in version.h).

I'm not really satisfied by the shell command, perhaps a regex would be better? At least it works.
I wonder too if it would a good idea to do the same with the date.

(It make me more time to fight with branches and ssh keys than with the code! ^^)

Have a nice week,
Stéphane
