### PR TITLE
Generated binary is not stripped anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ rolldice.o: rolldice.c $(INCLUDES)
 install: $(EXECFILES)
 	install -d $(BIN) $(MAN)
 	install ./rolldice $(BIN)
-	strip $(BIN)/rolldice
 	gzip -9 -c rolldice.6 > rolldice.6.gz
 	install -m644 rolldice.6.gz $(MAN)
 


### PR DESCRIPTION
This is a one-liner patch! Jusst deeted the strip command as I talked in a previous message.

The idea behind it is that the binary size is not really a problem today and the keeped data could help if users find bugs.

Have a nice day!
Stéphane
