### PR TITLE
Fix pointers

### DIFF
--- a/main.c
+++ b/main.c
@@ -118,18 +118,17 @@ void print_rolls(int *dice_nums) {
  * Returns: EX_OK or EXIT_DATAERR (if bad stdin)
  */
 int roll_from_stdin(){
-     int *dice_nums = NULL;
+     int dice_nums[DICE_ARRAY_SIZE];
      static char *line = (char *)NULL;
 
      line = readline("");
      while(line){
-       dice_nums = parse_string( line );
+       parse_string( line, dice_nums );
        if ( dice_nums == NULL ) {
          return EX_DATAERR;
        }
        free(line);
        print_rolls(dice_nums);
-       free(dice_nums);
 
        line = (char *)NULL;
        line = readline("");
@@ -143,16 +142,15 @@ int roll_from_stdin(){
  * Returns: EX_OK or EXIT_DATAERR (if bad command line)
  */
 int roll_from_args(char **argv){
-    int *dice_nums = NULL;
+    int dice_nums[DICE_ARRAY_SIZE];
     int index;
 
     for(index = optind; argv[index] != NULL; index++) {
-      dice_nums = parse_string( argv[index] );
+      parse_string( argv[index], dice_nums );
       if ( dice_nums == NULL ) {
         return EX_DATAERR;
       }
      print_rolls(dice_nums);
-     free(dice_nums);
     }
     return EX_OK;
 }

--- a/rolldice.c
+++ b/rolldice.c
@@ -15,12 +15,12 @@ static FILE* ran_dev;
 
 // Local functions
 int get_num_dice(int temp_int, int default_num);
-int *get_num_sides(char *dice_string, int temp_int, int *res_int);
-int *get_num_drop(char *dice_string, int temp_int, int *res_int);
-int *get_num_rolls(int temp_int, int *res_int);
-int *get_mutiplier(char *dice_string, int temp_int, int *res_int);
-int *get_plus_modifier(char *dice_string, int temp_int, int *res_int);
-int *get_minus_modifier(char *dice_string, int temp_int, int *res_int);
+int get_num_sides(char *dice_string, int temp_int);
+int get_num_drop(char *dice_string, int temp_int);
+int get_num_rolls(int temp_int);
+int get_mutiplier(char *dice_string, int temp_int);
+int get_plus_modifier(char *dice_string, int temp_int);
+int get_minus_modifier(char *dice_string, int temp_int);
 int is_too_big(int num);
 void print_parse_error(const char * label, const int too_big_error);
 
@@ -64,14 +64,9 @@ int rolldie ( int num_sides ) {
  * Returns: int * - array of nums describing the different aspects of the 
  * dice to be rolled
  */
-int *parse_string(char *dice_string) {
-    int temp_int = -1, *dice_nums, *res_int;
+void parse_string(char *dice_string, int *dice_nums) {
+    int temp_int = -1, res_int;
     const int DEFAULT_NUM_DICE = 1;
-
-    if((dice_nums = malloc ( DICE_ARRAY_SIZE * sizeof(int))) == NULL){
-        perror("rolldice");
-        exit(EX_OSERR);
-    }
 
     dice_nums[NUM_ROLLS] = 1;
     dice_nums[NUM_DICE] = DEFAULT_NUM_DICE;
@@ -90,62 +85,62 @@ int *parse_string(char *dice_string) {
 	    case 'd':
             dice_nums[NUM_DICE] = get_num_dice(temp_int, DEFAULT_NUM_DICE);
             dice_string++;
-            res_int = get_num_sides(dice_string, temp_int, res_int);
-            if (res_int == NULL){
-                free(dice_nums);
-                return NULL;
+            res_int = get_num_sides(dice_string, temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[NUM_SIDES] = *res_int;
+                dice_nums[NUM_SIDES] = res_int;
             }
             break;
 	    case 's':
             dice_string++;
-            res_int = get_num_drop(dice_string, temp_int, res_int);
-            if (res_int == NULL){
-		        free(dice_nums);
-                return NULL;
+            res_int = get_num_drop(dice_string, temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[NUM_DROP] = *res_int;
+                dice_nums[NUM_DROP] = res_int;
             }
 		    break;
 	    case 'x':
             dice_string++;
-            res_int = get_num_rolls(temp_int, res_int);
-            if (res_int == NULL){
-                free(dice_nums);
-                return NULL;
+            res_int = get_num_rolls(temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[NUM_ROLLS] = *res_int;
+                dice_nums[NUM_ROLLS] = res_int;
             }
             break;
 	    case '*':
             dice_string++;
-            res_int = get_mutiplier(dice_string, temp_int, res_int);
-            if (res_int == NULL){
-                free(dice_nums);
-                return NULL;
+            res_int = get_mutiplier(dice_string, temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[MULTIPLIER] = *res_int;
+                dice_nums[MULTIPLIER] = res_int;
             }
             break;
 	    case '+':
             dice_string++;
-            res_int = get_plus_modifier(dice_string, temp_int, res_int);
-            if (res_int == NULL){
-                free(dice_nums);
-                return NULL;
+            res_int = get_plus_modifier(dice_string, temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[MODIFIER] = *res_int;
+                dice_nums[MODIFIER] = res_int;
             }
             break;
 	    case '-':
             dice_string++;
-            res_int = get_minus_modifier(dice_string, temp_int, res_int);
-            if (res_int == NULL){
-                free(dice_nums);
-                return NULL;
+            res_int = get_minus_modifier(dice_string, temp_int);
+            if (!res_int){
+                dice_nums = NULL;
+                return;
             } else {
-                dice_nums[MODIFIER] = *res_int;
+                dice_nums[MODIFIER] = res_int;
             }
             break;
         default:
@@ -155,8 +150,6 @@ int *parse_string(char *dice_string) {
 	    temp_int = 0;
 	}
     }
-    
-    return dice_nums;
 }
 
 int get_num_dice(int temp_int, int default_num){
@@ -180,75 +173,68 @@ void print_parse_error(const char * label, const int too_big_error){
 
 }
 
-int *get_num_sides(char *dice_string, int temp_int, int *res_int){
+int get_num_sides(char *dice_string, int temp_int){
     const char *PERCENT = "%";
     if(strncmp(dice_string, PERCENT, 1) == 0){
         temp_int = 100;
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
     else if( (sscanf(dice_string, "%d", &temp_int) < 1 ) ||
             (temp_int < 2) || is_too_big(temp_int) ) {
         print_parse_error("number of dice faces", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 
-int *get_num_drop(char *dice_string, int temp_int, int *res_int){
+int get_num_drop(char *dice_string, int temp_int){
     if( (sscanf(dice_string, "%d", &temp_int) < 1) ||
         (temp_int < 0) || is_too_big(temp_int) ) {
         print_parse_error("number of dropped dice", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 
-int *get_num_rolls(int temp_int, int *res_int){
+int get_num_rolls(int temp_int){
     if( ( temp_int < 1 ) || is_too_big(temp_int) ) {
         print_parse_error("number of rolled dice", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 
-int *get_mutiplier(char *dice_string, int temp_int, int *res_int){
+int get_mutiplier(char *dice_string, int temp_int){
     if( (sscanf(dice_string, "%d", &temp_int) < 1) ||
         (temp_int < 0) || is_too_big(temp_int) ) {
         print_parse_error("multiplier", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 
-int *get_plus_modifier(char *dice_string, int temp_int, int *res_int){
+int get_plus_modifier(char *dice_string, int temp_int){
     if( (sscanf(dice_string, "%d", &temp_int) < 1) ||
         (temp_int < 0) || is_too_big(temp_int) ) {
         print_parse_error("add modifier", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 
-int *get_minus_modifier(char *dice_string, int temp_int, int *res_int){
+int get_minus_modifier(char *dice_string, int temp_int){
     if( (sscanf(dice_string, "%d", &temp_int) < 1) ||
         (temp_int < 0) || is_too_big(temp_int) ) {
         print_parse_error("minus modifier", is_too_big(temp_int));
-        return NULL;
+        return 0;
     } else {
         temp_int = - temp_int;
-        res_int = &temp_int;
-        return res_int;
+        return temp_int;
     }
 }
 

--- a/rolldice.h
+++ b/rolldice.h
@@ -65,6 +65,6 @@
 typedef enum {UNDEF, URANDOM, RANDOM} rand_type;
 
 // External function declarations for using rolldice() and kin.
-extern int *parse_string(char *dice_string);
+extern void parse_string(char *dice_string, int *dice_nums);
 extern int rolldie(int num_sides);
 extern void init_random(rand_type rand_file);


### PR DESCRIPTION
This patch makes the functions not return `int *` pointers, returning actual integers instead, and also makes `parse_string` not return an `int *` pointer but use an actual C `int` array.