### PR TITLE
Repeat last dice roll in interactive mode

### DIFF
--- a/main.c
+++ b/main.c
@@ -118,7 +118,7 @@ void print_rolls(int *dice_nums) {
  * Returns: EX_OK or EXIT_DATAERR (if bad stdin)
  */
 int roll_from_stdin(){
-     int dice_nums[DICE_ARRAY_SIZE];
+     int dice_nums[DICE_ARRAY_SIZE] = {};
      static char *line = (char *)NULL;
 
      line = readline("");
@@ -142,7 +142,7 @@ int roll_from_stdin(){
  * Returns: EX_OK or EXIT_DATAERR (if bad command line)
  */
 int roll_from_args(char **argv){
-    int dice_nums[DICE_ARRAY_SIZE];
+    int dice_nums[DICE_ARRAY_SIZE] = {};
     int index;
 
     for(index = optind; argv[index] != NULL; index++) {

--- a/rolldice.c
+++ b/rolldice.c
@@ -61,15 +61,16 @@ int rolldie ( int num_sides ) {
 /* parse_string() - Parses a string for dice rolling attributes
  *
  * Parameters: char *dice_string - string to parse
- * Returns: int * - array of nums describing the different aspects of the 
- * dice to be rolled
+ *             int *dice_nums - array of size DICE_ARRAY_SIZE
+ *                       where the parsed values will be stored
+ * Returns: int - return non-zero value if error occured
  */
-void parse_string(char *dice_string, int *dice_nums) {
+int parse_string(char *dice_string, int *dice_nums) {
     int temp_int = -1, res_int;
     const int DEFAULT_NUM_DICE = 1;
 
     if (*dice_string == '\0' && dice_nums[NUM_INITIALIZED]) {
-        return;
+        return 0;
     }
     else {
         dice_nums[NUM_ROLLS] = 1;
@@ -93,8 +94,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_num_sides(dice_string, temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[NUM_SIDES] = res_int;
             }
@@ -103,8 +103,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_num_drop(dice_string, temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[NUM_DROP] = res_int;
             }
@@ -113,8 +112,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_num_rolls(temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[NUM_ROLLS] = res_int;
             }
@@ -123,8 +121,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_mutiplier(dice_string, temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[MULTIPLIER] = res_int;
             }
@@ -133,8 +130,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_plus_modifier(dice_string, temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[MODIFIER] = res_int;
             }
@@ -143,8 +139,7 @@ void parse_string(char *dice_string, int *dice_nums) {
             dice_string++;
             res_int = get_minus_modifier(dice_string, temp_int);
             if (!res_int){
-                dice_nums = NULL;
-                return;
+                return 1;
             } else {
                 dice_nums[MODIFIER] = res_int;
             }
@@ -156,6 +151,7 @@ void parse_string(char *dice_string, int *dice_nums) {
 	    temp_int = 0;
 	}
     }
+    return 0;
 }
 
 int get_num_dice(int temp_int, int default_num){

--- a/rolldice.c
+++ b/rolldice.c
@@ -68,13 +68,19 @@ void parse_string(char *dice_string, int *dice_nums) {
     int temp_int = -1, res_int;
     const int DEFAULT_NUM_DICE = 1;
 
-    dice_nums[NUM_ROLLS] = 1;
-    dice_nums[NUM_DICE] = DEFAULT_NUM_DICE;
-    dice_nums[NUM_SIDES] = 6;
-    dice_nums[MULTIPLIER] = 1;
-    dice_nums[MODIFIER] = 0;
-    dice_nums[NUM_DROP] = 0;
-
+    if (*dice_string == '\0' && dice_nums[NUM_INITIALIZED]) {
+        return;
+    }
+    else {
+        dice_nums[NUM_ROLLS] = 1;
+        dice_nums[NUM_DICE] = DEFAULT_NUM_DICE;
+        dice_nums[NUM_SIDES] = 6;
+        dice_nums[MULTIPLIER] = 1;
+        dice_nums[MODIFIER] = 0;
+        dice_nums[NUM_DROP] = 0;
+        dice_nums[NUM_INITIALIZED] = 1;
+    }
+    
     while(*dice_string != '\0') {
 	if( isdigit(*dice_string) ) {
 	    sscanf(dice_string, "%d", &temp_int);

--- a/rolldice.h
+++ b/rolldice.h
@@ -63,6 +63,6 @@
 typedef enum {UNDEF, URANDOM, RANDOM} rand_type;
 
 // External function declarations for using rolldice() and kin.
-extern void parse_string(char *dice_string, int *dice_nums);
+extern int parse_string(char *dice_string, int *dice_nums);
 extern int rolldie(int num_sides);
 extern void init_random(rand_type rand_file);

--- a/rolldice.h
+++ b/rolldice.h
@@ -41,7 +41,8 @@
 #define MULTIPLIER 3
 #define MODIFIER 4
 #define NUM_DROP 5
-#define DICE_ARRAY_SIZE 6
+#define NUM_INITIALIZED 6
+#define DICE_ARRAY_SIZE 7
 
 /* The following #defines give the tokens for each part of the format
  * string.  Perhaps eventually I'll change parse_string to use strtok()


### PR DESCRIPTION
roll_from_stdin is easily usable as interactive mode. But typing the same dice string multiple times is cumbersome. Now you can repeat your last dice roll by entering an empty line.
The num_dice array now has to be initialized to all zeros before being passed to parse_string().