### PR TITLE
Add ctype.h header for isdigit function

### DIFF
--- a/rolldice.h
+++ b/rolldice.h
@@ -30,6 +30,9 @@
 /* For some bounds */
 #include <limits.h>
 
+/* For the isdigit() function */
+#include <ctype.h>
+
 /* The following #defines give the position of each important dice-related
  * number inside of the dice_nums array.  The final #define gives us the
  * size of the dice_nums array, which should be the number of other 


### PR DESCRIPTION
`isdigit` is provided from `ctype.h`. This header may not need to be added on all platforms (perhaps included by some other header) but it is needed on at least current macOS (14).